### PR TITLE
Make logging less noisy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,7 @@ services:
       env_file: .env
       environment:
         - REPOSITORY_BASEURI=${APIX_BASEURI}
+        - LOG.org.apache.jena.riot=ERROR
       ports:
         - "${PACKAGE_INGEST_PORT}:${PACKAGE_INGEST_PORT}"
       depends_on:

--- a/package-ingest-impl/src/main/java/org/dataconservancy/packaging/impl/OpenPackageService.java
+++ b/package-ingest-impl/src/main/java/org/dataconservancy/packaging/impl/OpenPackageService.java
@@ -65,7 +65,7 @@ public class OpenPackageService {
         while ((entry = ais.getNextEntry()) != null) {
 
             final File file = extract(dest_dir, entry, ais);
-            LOG.info("Extracted {} to {}", entry.getName(), file.getAbsolutePath());
+            LOG.debug("Extracted {} to {}", entry.getName(), file.getAbsolutePath());
 
             final String root = (entry.getName().split("/"))[0];
 

--- a/package-ingest-impl/src/main/java/org/dataconservancy/packaging/impl/deposit/SingleDepositManager.java
+++ b/package-ingest-impl/src/main/java/org/dataconservancy/packaging/impl/deposit/SingleDepositManager.java
@@ -113,7 +113,7 @@ public class SingleDepositManager implements PackageDepositManager {
             depositor.commit();
             listener.onEvent(EventType.SUCCESS, null, null, "Ingest successfully completed");
         } catch (final Throwable e) {
-            LOG.debug("Walking the package produced an error:", e);
+            LOG.info("Walking the package produced an error:", e);
 
             // Rollback if error!
             try {


### PR DESCRIPTION
Fine-grained logging control has already been added and documented:
[LOG.*](package-ingest-docker/README.md#log)

This further tweaks the defaults by:
* Reduce package extraction logs to 'debug' level
* Set Apache riot at ERROR by default
* Log exceptions when committing transactions at INFO

Resolves #7 